### PR TITLE
Add travis job for ppc64le. Update bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,13 @@ dist: trusty
 sudo: false
 cache: bundler
 language: ruby
+arch: 
+  - amd64
+  - ppc64le
 
-before_install: gem update --remote bundler
+before_install: 
+  - if [[ "$TRAVIS_CPU_ARCH" = "ppc64le" ]]; then bundle update --bundler; fi
+  - gem update --remote bundler
 
 install:
   - bundle install --retry=3


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date. 