### PR TITLE
Add macro block, subs attributes, global config support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ Metrics/MethodLength:
   Max: 20
 
 Metrics/ClassLength:
-  Max: 200
+  Max: 210
   Exclude:
     - test/test_plantuml.rb
 

--- a/lib/asciidoctor-plantuml.rb
+++ b/lib/asciidoctor-plantuml.rb
@@ -6,4 +6,5 @@ require_relative 'asciidoctor_plantuml/plantuml'
 
 Asciidoctor::Extensions.register do
   block Asciidoctor::PlantUml::BlockProcessor, :plantuml
+  block_macro Asciidoctor::PlantUml::BlockMacroProcessor, :plantuml
 end

--- a/test/fixtures/config.puml
+++ b/test/fixtures/config.puml
@@ -1,0 +1,3 @@
+skinparam monochrome true
+skinparam backgroundColor transparent
+skinparam style strictuml

--- a/test/fixtures/test.puml
+++ b/test/fixtures/test.puml
@@ -1,0 +1,4 @@
+@startuml
+User -> (Start)
+User --> (Use the application) : Label
+@enduml

--- a/test/test_plantuml.rb
+++ b/test/test_plantuml.rb
@@ -184,10 +184,69 @@ DOC_SVG = <<~ENDOFSTRING
   ----
 ENDOFSTRING
 
+DOC_BLOCK_MACRO = <<~ENDOFSTRING
+  = Hello PlantUML!
+
+  .Title Of this
+  plantuml::test/fixtures/test.puml[]
+ENDOFSTRING
+
+DOC_BLOCK_MACRO_MISSING_FILE = <<~ENDOFSTRING
+  = Hello PlantUML!
+
+  .Title Of this
+  plantuml::test/fixtures/missing.puml[]
+ENDOFSTRING
+
+DOC_SUBS_ATTRIBUTES = <<~ENDOFSTRING
+  = Hello PlantUML!
+  :text: Label
+
+  [plantuml, format="png", subs="attributes+"]
+  .Title Of this
+  ----
+  User -> (Start)
+  User --> (Use the application) : {text}
+  ----
+ENDOFSTRING
+
+DOC_CONFIG_INCLUDE = <<~ENDOFSTRING
+  = Hello PlantUML!
+  :plantuml-include: test/fixtures/config.puml
+
+  [plantuml, format="png"]
+  .Title Of this
+  ----
+  User -> (Start)
+  User --> (Use the application) : Label
+  ----
+ENDOFSTRING
+
+DOC_CONFIG_INCLUDE_MISSING_FILE = <<~ENDOFSTRING
+  = Hello PlantUML!
+  :plantuml-include: test/fixtures/missing.puml
+
+  [plantuml, format="png"]
+  .Title Of this
+  ----
+  User -> (Start)
+  User --> (Use the application) : Label
+  ----
+ENDOFSTRING
+
+DOC_CONFIG_INCLUDE_MACRO_BLOCK = <<~ENDOFSTRING
+  = Hello PlantUML!
+  :plantuml-include: test/fixtures/config.puml
+
+  [plantuml, format="png"]
+  plantuml::test/fixtures/test.puml[]
+ENDOFSTRING
+
 class PlantUmlTest < Test::Unit::TestCase
   GENURL = 'http://localhost:8080/plantuml/png/U9npA2v9B2efpStX2YrEBLBGjLFG20Q9Q4Bv804WIw4a8rKXiQ0W9pCviIGpFqzJmKh19p4fDOVB8JKl1QWT05kd5wq0'
   GENURL2 = 'http://localhost:8080/plantuml/png/U9npA2v9B2efpStXYdRszmqmZ8NGHh4mleAkdGAAa15G22Pc7Clba9gN0jGE00W75Cm0'
   GENURL_ENCODING = 'http://localhost:8080/plantuml/png/~1U9npA2v9B2efpStX2YrEBLBGjLFG20Q9Q4Bv804WIw4a8rKXiQ0W9pCviIGpFqzJmKh19p4fDOVB8JKl1QWT05kd5wq0'
+  GENURL_CONFIG = 'http://localhost:8080/plantuml/png/~1U9nDZJ4Emp08HVUSWh4PUe4ELQIktQeUW3YeiMA31NZexKEg3bc-Fly1Vp97zLxBO5lcXeeLgh2aLQKIk7OwaHdJzb7fl3oaY0P6ja34Vjeo_nOArPn-dzz62jSxN5v7r_YVZo0S-4g0hPMSqBFm23Tuuanbc8YNEDy1SzOwlG00'
   SVGGENURL = 'http://localhost:8080/plantuml/svg/~1U9npA2v9B2efpStX2YrEBLBGjLFG20Q9Q4Bv804WIw4a8rKXiQ0W9pCviIGpFqzJmKh19p4fDOVB8JKl1QWT05kd5wq0'
 
   def setup
@@ -300,6 +359,76 @@ class PlantUmlTest < Test::Unit::TestCase
     element = elements.first
 
     assert_equal GENURL_ENCODING, element['src']
+  end
+
+  def test_plantuml_block_macro_processor
+    html = ::Asciidoctor.convert(StringIO.new(DOC_BLOCK_MACRO), backend: 'html5')
+    page = Nokogiri::HTML(html)
+
+    elements = page.css('img.plantuml')
+
+    assert_equal elements.size, 1
+
+    element = elements.first
+
+    assert_equal GENURL, element['src']
+  end
+
+  def test_should_show_file_error
+    html = ::Asciidoctor.convert(StringIO.new(DOC_BLOCK_MACRO_MISSING_FILE), backend: 'html5')
+    page = Nokogiri::HTML(html)
+
+    elements = page.css('pre.plantuml-error')
+    assert_equal elements.size, 1
+    assert_includes html, 'No such file or directory'
+  end
+
+  def test_plantuml_subs_attributes
+    html = ::Asciidoctor.convert(StringIO.new(DOC_SUBS_ATTRIBUTES), backend: 'html5')
+    page = Nokogiri::HTML(html)
+
+    elements = page.css('img.plantuml')
+
+    assert_equal elements.size, 1
+
+    element = elements.first
+
+    assert_equal GENURL_ENCODING, element['src']
+  end
+
+  def test_plantuml_config_include
+    html = ::Asciidoctor.convert(StringIO.new(DOC_CONFIG_INCLUDE), backend: 'html5')
+    page = Nokogiri::HTML(html)
+
+    elements = page.css('img.plantuml')
+
+    assert_equal elements.size, 1
+
+    element = elements.first
+
+    assert_equal GENURL_CONFIG, element['src']
+  end
+
+  def test_plantuml_config_include_missing_file
+    html = ::Asciidoctor.convert(StringIO.new(DOC_CONFIG_INCLUDE_MISSING_FILE), backend: 'html5')
+    page = Nokogiri::HTML(html)
+
+    elements = page.css('pre.plantuml-error')
+    assert_equal elements.size, 1
+    assert_includes html, 'No such file or directory'
+  end
+
+  def test_plantuml_config_include_macro_block
+    html = ::Asciidoctor.convert(StringIO.new(DOC_CONFIG_INCLUDE_MACRO_BLOCK), backend: 'html5')
+    page = Nokogiri::HTML(html)
+
+    elements = page.css('img.plantuml')
+
+    assert_equal elements.size, 1
+
+    element = elements.first
+
+    assert_equal GENURL_CONFIG, element['src']
   end
 
   def test_plantuml_id_attribute


### PR DESCRIPTION
### Add macro block support
includes #19 
closes #18 

### Add subs attribute support (AsciiDoc variables)
closes #17 

### Add global PlantUML config file include support with `:plantuml-include:`
Support a global PlantUML configuration file.

Add the functionality of the PlantUML command line: https://plantuml.com/command-line#6a26f548831e6a8c
> <pre>-I/path/to/file                Include file as if '!include file' was used</pre>

Other tools such as Kroki have similar features with `:kroki-plantuml-include: path/to/file.puml`.

#### How to use
Just add the variable `:plantuml-include: path/to/file.puml` inside your AsciiDoc file.