### PR TITLE
Honor asciidoctor safe mode setting.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,10 +9,10 @@ Naming/FileName:
     - lib/asciidoctor-plantuml.rb
 
 Metrics/MethodLength:
-  Max: 20
+  Max: 50
 
 Metrics/ClassLength:
-  Max: 210
+  Max: 250
   Exclude:
     - test/test_plantuml.rb
 

--- a/lib/asciidoctor_plantuml/plantuml.rb
+++ b/lib/asciidoctor_plantuml/plantuml.rb
@@ -95,7 +95,7 @@ module Asciidoctor
 
           unless config_path.empty?
             begin
-              source_file = parent.document.path_resolver.system_path(config_path, base_dir, base_dir, recover: false)
+              source_file = parent.document.normalize_system_path(config_path, base_dir, base_dir, recover: false)
               content = insert_config_to_content(parent, source_file, content, attrs)
             rescue StandardError => e
               return plantuml_invalid_file(source_file, e.message, attrs)
@@ -123,7 +123,7 @@ module Asciidoctor
 
         def plantuml_content_from_file(parent, target, attrs = {})
           base_dir = parent.document.base_dir
-          source_file = parent.document.path_resolver.system_path(target, base_dir, base_dir, recover: false)
+          source_file = parent.document.normalize_system_path(target, base_dir, base_dir, recover: false)
           File.open(source_file, 'r') do |f|
             return plantuml_content(parent, f, attrs)
           end

--- a/lib/asciidoctor_plantuml/plantuml.rb
+++ b/lib/asciidoctor_plantuml/plantuml.rb
@@ -122,9 +122,8 @@ module Asciidoctor
 
         def plantuml_content_from_file(parent, target, attrs = {})
           source_file = parent.document.normalize_system_path(target, nil, nil, recover: false)
-          ::File.open(source_file, mode: 'r') do |f|
-            return plantuml_content(parent, f, attrs)
-          end
+          content = ::File.open(source_file, mode: FILE_READ_MODE)
+          return plantuml_content(parent, content, attrs)
         rescue StandardError => e
           plantuml_invalid_file(source_file, e.message, attrs)
         rescue SecurityError => e
@@ -158,12 +157,10 @@ module Asciidoctor
         private
 
         def insert_config_to_content(parent, config_path, content, attrs)
-          ::File.open(config_path, 'r') do |file|
-            config = file.read
-            subs = attrs['subs']
-            config = parent.apply_subs(config, parent.resolve_subs(subs)) if subs
-            return content.dup.insert(content.index("\n"), "\n#{config}") unless config.empty?
-          end
+          config = File.read(config_path, mode: FILE_READ_MODE)
+          subs = attrs['subs']
+          config = parent.apply_subs(config, parent.resolve_subs(subs)) if subs
+          return content.dup.insert(content.index("\n"), "\n#{config}") unless config.empty?
         end
 
         def plantuml_txt_content(code, format, attrs = {})

--- a/lib/asciidoctor_plantuml/plantuml.rb
+++ b/lib/asciidoctor_plantuml/plantuml.rb
@@ -123,7 +123,7 @@ module Asciidoctor
         def plantuml_content_from_file(parent, target, attrs = {})
           source_file = parent.document.normalize_system_path(target, nil, nil, recover: false)
           content = ::File.open(source_file, mode: FILE_READ_MODE)
-          return plantuml_content(parent, content, attrs)
+          plantuml_content(parent, content, attrs)
         rescue StandardError => e
           plantuml_invalid_file(source_file, e.message, attrs)
         rescue SecurityError => e

--- a/lib/asciidoctor_plantuml/plantuml.rb
+++ b/lib/asciidoctor_plantuml/plantuml.rb
@@ -124,7 +124,7 @@ module Asciidoctor
         def plantuml_content_from_file(parent, target, attrs = {})
           base_dir = parent.document.base_dir
           source_file = parent.document.normalize_system_path(target, base_dir, base_dir, recover: false)
-          File.open(source_file, 'r') do |f|
+          ::File.open(source_file, mode: 'r') do |f|
             return plantuml_content(parent, f, attrs)
           end
         rescue StandardError => e
@@ -160,7 +160,7 @@ module Asciidoctor
         private
 
         def insert_config_to_content(parent, config_path, content, attrs)
-          File.open(config_path, 'r') do |file|
+          ::File.open(config_path, 'r') do |file|
             config = file.read
             subs = attrs['subs']
             config = parent.apply_subs(config, parent.resolve_subs(subs)) if subs

--- a/lib/asciidoctor_plantuml/plantuml.rb
+++ b/lib/asciidoctor_plantuml/plantuml.rb
@@ -90,12 +90,11 @@ module Asciidoctor
           content = "@startuml\n#{content}\n@enduml" unless content =~ /^@start.*@end[a-z]*$/m
 
           # insert global plantuml config after first line
-          base_dir = parent.document.base_dir
           config_path = parent.attr('plantuml-include', '', true)
 
           unless config_path.empty?
             begin
-              source_file = parent.document.normalize_system_path(config_path, base_dir, base_dir, recover: false)
+              source_file = parent.document.normalize_system_path(config_path, nil, nil, recover: false)
               content = insert_config_to_content(parent, source_file, content, attrs)
             rescue StandardError => e
               return plantuml_invalid_file(source_file, e.message, attrs)
@@ -122,8 +121,7 @@ module Asciidoctor
         end
 
         def plantuml_content_from_file(parent, target, attrs = {})
-          base_dir = parent.document.base_dir
-          source_file = parent.document.normalize_system_path(target, base_dir, base_dir, recover: false)
+          source_file = parent.document.normalize_system_path(target, nil, nil, recover: false)
           ::File.open(source_file, mode: 'r') do |f|
             return plantuml_content(parent, f, attrs)
           end


### PR DESCRIPTION
- Use document path_resolver to resolve included files which ensures
  asciidoctor safe mode is honored.
- If a file outside the jail is included the resulting image will
  contain such error.
- Add "read only" flag to File.open calls.

Closes #33 