### PR TITLE
(fix): allow previous behavior where parent node was not necessary

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', truffleruby-head]
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', truffleruby-head]
 
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,12 @@ Metrics/ClassLength:
 Metrics/AbcSize:
   Max: 30
 
+Metrics/PerceivedComplexity:
+  Max: 20
+
+Metrics/CyclomaticComplexity:
+  Max: 20
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 

--- a/README.adoc
+++ b/README.adoc
@@ -29,13 +29,13 @@ commands:
 
 A diagram is written inside an open block inside any asciidoc file:
 
-----
+....
 [plantuml, format="png", id="myId"]
 ----
 alice -> bob : hello
 bob -> alice : hello
 ----
-----
+....
 
 NOTE: You can omit the @startuml/@enduml delimiters. The extension adds them if missing.
 

--- a/lib/asciidoctor_plantuml/plantuml.rb
+++ b/lib/asciidoctor_plantuml/plantuml.rb
@@ -79,7 +79,7 @@ module Asciidoctor
         end
 
         def plantuml_content_format(parent, code, format, attrs = {})
-          content = code.read
+          content = code.respond_to?(:read) ? code.read : code
 
           # add @start... and @end... if missing
           content = "@startuml\n#{content}\n@enduml" unless content =~ /^@start.*@end[a-z]*$/m

--- a/lib/asciidoctor_plantuml/plantuml.rb
+++ b/lib/asciidoctor_plantuml/plantuml.rb
@@ -90,7 +90,6 @@ module Asciidoctor
             subs = attrs['subs']
             content = parent.apply_subs(content, parent.resolve_subs(subs)) if subs
 
-
             # insert global plantuml config after first line
             config_path = parent.attr('plantuml-include', '', true)
 

--- a/lib/asciidoctor_plantuml/plantuml.rb
+++ b/lib/asciidoctor_plantuml/plantuml.rb
@@ -81,25 +81,28 @@ module Asciidoctor
         def plantuml_content_format(parent, code, format, attrs = {})
           content = code.read
 
-          # honor subs attributes
-          # e.g. replace asciidoc variables
-          subs = attrs['subs']
-          content = parent.apply_subs(content, parent.resolve_subs(subs)) if subs
-
           # add @start... and @end... if missing
           content = "@startuml\n#{content}\n@enduml" unless content =~ /^@start.*@end[a-z]*$/m
 
-          # insert global plantuml config after first line
-          config_path = parent.attr('plantuml-include', '', true)
+          if parent
+            # honor subs attributes
+            # e.g. replace asciidoc variables
+            subs = attrs['subs']
+            content = parent.apply_subs(content, parent.resolve_subs(subs)) if subs
 
-          unless config_path.empty?
-            begin
-              source_file = parent.document.normalize_system_path(config_path, nil, nil, recover: false)
-              content = insert_config_to_content(parent, source_file, content, attrs)
-            rescue StandardError => e
-              return plantuml_invalid_file(source_file, e.message, attrs)
-            rescue SecurityError => e
-              return plantuml_insecure_file(source_file, e.message, attrs)
+
+            # insert global plantuml config after first line
+            config_path = parent.attr('plantuml-include', '', true)
+
+            unless config_path.empty?
+              begin
+                source_file = parent.document.normalize_system_path(config_path, nil, nil, recover: false)
+                content = insert_config_to_content(parent, source_file, content, attrs)
+              rescue StandardError => e
+                return plantuml_invalid_file(source_file, e.message, attrs)
+              rescue SecurityError => e
+                return plantuml_insecure_file(source_file, e.message, attrs)
+              end
             end
           end
 


### PR DESCRIPTION
This PR allows the plantuml_contant() first argument `parent` to be null so software that uses thes gem outside PlantUML macro preprocessor can still use this method without need to pass an [AsciiDoctor::AbstractNode](https://www.rubydoc.info/gems/asciidoctor/Asciidoctor%2FAbstractNode:normalize_system_path) as parent.