### PR TITLE
chore: add ruby 3.3 and 3.4 to ci workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version:
-          ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", truffleruby-head]
+        ruby-version: ["3.2", "3.3", "3.4", truffleruby-head]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,26 +2,26 @@ name: Ruby
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', truffleruby-head]
+        ruby-version:
+          ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3,4", truffleruby-head]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Run tests
-      run: |
-        bundle exec rubocop
-        bundle exec rake
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run tests
+        run: |
+          bundle exec rubocop
+          bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3,4", truffleruby-head]
+          ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", truffleruby-head]
 
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
 ---
+plugins:
+  - rubocop-rake
+
 AllCops:
   NewCops: enable
   TargetRubyVersion: 2.6

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,9 @@
 source 'https://rubygems.org'
-gemspec
+
+gem 'asciidoctor', '>= 2.0.17', '< 3.0.0'
+gem 'bundler', '~> 2.2'
+gem 'nokogiri', '~> 1.13.6'
+gem 'rake', '~> 13.0'
+gem 'rubocop', '~> 1.28'
+gem 'rubocop-rake', '~> 0.7'
+gem 'test-unit', '~> 3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,53 +1,61 @@
-PATH
-  remote: .
-  specs:
-    asciidoctor-plantuml (0.1.1)
-      asciidoctor (>= 2.0.17, < 3.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    asciidoctor (2.0.17)
-    ast (2.4.2)
-    mini_portile2 (2.8.0)
+    asciidoctor (2.0.23)
+    ast (2.4.3)
+    json (2.13.2)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    mini_portile2 (2.8.9)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    parallel (1.22.1)
-    parser (3.1.2.0)
+    parallel (1.27.0)
+    parser (3.3.9.0)
       ast (~> 2.4.1)
-    power_assert (2.0.1)
-    racc (1.6.1)
+      racc
+    power_assert (2.0.5)
+    prism (1.4.0)
+    racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.0.6)
-    regexp_parser (2.3.1)
-    rexml (3.3.9)
-    rubocop (1.28.2)
+    rake (13.3.0)
+    regexp_parser (2.11.2)
+    rubocop (1.80.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.17.0, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.46.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.17.0)
-      parser (>= 3.1.1.0)
-    ruby-progressbar (1.11.0)
-    test-unit (3.5.3)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.46.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    rubocop-rake (0.7.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1)
+    ruby-progressbar (1.13.0)
+    test-unit (3.7.0)
       power_assert
-    unicode-display_width (2.1.0)
+    unicode-display_width (3.1.5)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
-  asciidoctor-plantuml!
+  asciidoctor (>= 2.0.17, < 3.0.0)
   bundler (~> 2.2)
   nokogiri (~> 1.13.6)
   rake (~> 13.0)
   rubocop (~> 1.28)
+  rubocop-rake (~> 0.7)
   test-unit (~> 3.5)
 
 BUNDLED WITH
-   2.2.27
+   2.7.1

--- a/asciidoctor-plantuml.gemspec
+++ b/asciidoctor-plantuml.gemspec
@@ -17,15 +17,8 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z -- */* {LICENSE,README,Rakefile}*`.split "\x0"
 
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  s.test_files = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
   s.required_ruby_version = '>= 2.6'
-  s.add_development_dependency 'bundler', '~> 2.2'
-  s.add_development_dependency 'nokogiri', '~> 1.13.6'
-  s.add_development_dependency 'rake', '~> 13.0'
-  s.add_development_dependency 'rubocop', '~> 1.28'
-  s.add_development_dependency 'test-unit', '~> 3.5'
-  s.add_runtime_dependency 'asciidoctor', '>= 2.0.17', '< 3.0.0'
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/asciidoctor_plantuml/plantuml.rb
+++ b/lib/asciidoctor_plantuml/plantuml.rb
@@ -47,7 +47,7 @@ module Asciidoctor
       ENCODINGS_MAGIC_STRINGS_MAP = Hash.new('')
       ENCODINGS_MAGIC_STRINGS_MAP['deflate'] = '~1'
 
-      URI_SCHEMES_REGEXP = ::URI::DEFAULT_PARSER.make_regexp(%w[http https])
+      URI_SCHEMES_REGEXP = ::URI::RFC2396_PARSER.make_regexp(%w[http https])
 
       class << self
         def valid_format?(format)
@@ -160,7 +160,7 @@ module Asciidoctor
           config = File.read(config_path, mode: FILE_READ_MODE)
           subs = attrs['subs']
           config = parent.apply_subs(config, parent.resolve_subs(subs)) if subs
-          return content.dup.insert(content.index("\n"), "\n#{config}") unless config.empty?
+          content.dup.insert(content.index("\n"), "\n#{config}") unless config.empty?
         end
 
         def plantuml_txt_content(code, format, attrs = {})


### PR DESCRIPTION
- Add ruby 3.3 and 3.4 to the CI workflow.
- Fix new linter errors.
- Add recommended rubocop-rake plugin.